### PR TITLE
fix: podfile error by using newer iOS version target

### DIFF
--- a/App_Resources/iOS/Podfile
+++ b/App_Resources/iOS/Podfile
@@ -1,0 +1,9 @@
+platform :ios, '13.0'
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+    end
+  end
+end

--- a/App_Resources/iOS/build.xcconfig
+++ b/App_Resources/iOS/build.xcconfig
@@ -4,3 +4,4 @@
 // To build for device with XCode you need to specify your development team.
 // DEVELOPMENT_TEAM = YOUR_TEAM_ID;
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+IPHONEOS_DEPLOYMENT_TARGET = 13.0;


### PR DESCRIPTION
Thanks for the demo. I ran into this error:

```
[!] CocoaPods could not find compatible versions for pod "NativeScript":
  In Podfile:
    NativeScript (from `../../node_modules/@nativescript/canvas/src-native/ios/NativeScript.podspec`)

Specs satisfying the `NativeScript (from `../../node_modules/@nativescript/canvas/src-native/ios/NativeScript.podspec`)` dependency were found, but they required a higher minimum deployment target.
'pod install' command failed.
```

These changes fixed it and allowed it to run. 